### PR TITLE
Represent as a color swatch in rich-content capable python environments.

### DIFF
--- a/colorutils/colorutils.py
+++ b/colorutils/colorutils.py
@@ -112,6 +112,23 @@ class Color(object):
     def __repr__(self):
         """ General representation """
         return "<Color {}>".format(self._color)
+    
+    def _repr_html_(self):
+        """ Rich representation for interactive notebook environments. """
+        return '''
+        <div style="
+            width:80px;
+            text-align:center;
+        ">
+            <code>{0}</code>
+        </div>
+        <div style="
+            background-color:{0};
+            width:80px;
+            height:80px;
+            border-style:solid;
+            border-width:2px
+        "></div>'''.format(self.hex)
 
     @property
     def red(self):

--- a/colorutils/colorutils.py
+++ b/colorutils/colorutils.py
@@ -119,11 +119,11 @@ class Color(object):
         <div style="display:flex">
             <div style="padding:0.5em;flex:0">
                 <div style="
-                    background-color:{1};
+                    background:{1};
                     height:105px;
                     width:105px;
-                    border-style:solid;
-                    border-width:2px
+                    border:2px solid;
+                    border-radius:6px;
                 "></div>
             </div>
             <div style="padding:0.5em;flex:1">

--- a/colorutils/colorutils.py
+++ b/colorutils/colorutils.py
@@ -116,19 +116,25 @@ class Color(object):
     def _repr_html_(self):
         """ Rich representation for interactive notebook environments. """
         return '''
-        <div style="
-            width:80px;
-            text-align:center;
-        ">
-            <code>{0}</code>
+        <div style="display:flex">
+            <div style="padding:0.5em;flex:0">
+                <div style="
+                    background-color:{1};
+                    height:105px;
+                    width:105px;
+                    border-style:solid;
+                    border-width:2px
+                "></div>
+            </div>
+            <div style="padding:0.5em;flex:1">
+                <code>rgb: {0}</code><br/>
+                <code>hex: {1}</code><br/>
+                <code>web: {2}</code><br/>
+                <code>yiq: {3}</code><br/>
+                <code>hsv: {4}</code>
+            </div>
         </div>
-        <div style="
-            background-color:{0};
-            width:80px;
-            height:80px;
-            border-style:solid;
-            border-width:2px
-        "></div>'''.format(self.hex)
+        '''.format(self.rgb, self.hex, self.web, self.yiq, self.hsv)
 
     @property
     def red(self):


### PR DESCRIPTION
Many interactive python environments have the capability to show objects in various rich representations, as long as the object provides the appropriate `_repr_*_` method. This PR adds a `_repr_html_` method to the `Color` object to allow these environments to automatically show a color swatch when asked to display such an object.

I showed off the concept in #12 initially, this is just a proper implementation that I've prettied up a bit from my initial prototype.

Here's an example Jupyter Notebook output with this PR applied:

![new output with repr_html](https://user-images.githubusercontent.com/3825306/98262710-ec2c3980-1f53-11eb-9084-b094e4f1e076.png)

Compared to before, when Jupyter was forced to fall back to using the `repr` value:

![old text-only output](https://user-images.githubusercontent.com/3825306/98262570-c69f3000-1f53-11eb-9d21-03eb27294523.png)